### PR TITLE
Fix Dimensions_UnitOfMeasurement

### DIFF
--- a/shipping/src/main/resources/Shipment.json
+++ b/shipping/src/main/resources/Shipment.json
@@ -6687,7 +6687,7 @@
         "type": "object",
         "description": "Dimensions information container. Note: Currently dimensions are not applicable to Ground Freight Pricing.\tLength + 2*(Width + Height) must be less than or equal to 165 IN or 330 CM.Required for Heavy Goods service. Package Dimension will be ignored for Simple Rate ",
         "properties": {
-          "UnitOfMeasurement": {
+          "Code": {
             "description": "Package dimensions measurement code. Valid codes: IN = Inches CM = Centimeters 00 = Metric Units Of Measurement 01 = English Units of Measurement\tThe unit of measurement must be valid for the Shipper country or territory. ",
             "maximum": 1,
             "type": "string",


### PR DESCRIPTION
Wrong Objectname in properties: "UnitOfMeasurement" changed to "Code".